### PR TITLE
Add monetization and sponsorship features

### DIFF
--- a/app/ai-assistant.html
+++ b/app/ai-assistant.html
@@ -16,6 +16,7 @@
                 <li><a href="projects.html">Project Management</a></li>
                 <li><a href="security.html">Cybersecurity</a></li>
                 <li class="active"><a href="ai-assistant.html">AI Assistant</a></li>
+                <li><a href="funding.html">Sponsorship & Funding</a></li>
             </ul>
         </nav>
     </div>

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -192,6 +192,150 @@ header {
     cursor: pointer;
 }
 
+/* Funding Page Styles */
+.progress-container {
+    width: 100%;
+    background-color: #ecf0f1;
+    border-radius: 20px;
+    margin: 15px 0;
+}
+
+.progress-bar {
+    background-color: #27ae60;
+    color: white;
+    padding: 5px 0;
+    text-align: center;
+    border-radius: 20px;
+    font-size: 14px;
+    font-weight: bold;
+}
+
+.funding-tiers {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+    margin-top: 30px;
+}
+
+.tier-card {
+    background: white;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    text-align: center;
+    transition: transform 0.3s;
+}
+
+.tier-card:hover {
+    transform: translateY(-5px);
+}
+
+.tier-card.featured {
+    border: 2px solid #3498db;
+    position: relative;
+}
+
+.tier-card.featured::after {
+    content: "Most Popular";
+    position: absolute;
+    top: -12px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #3498db;
+    color: white;
+    padding: 2px 12px;
+    border-radius: 20px;
+    font-size: 12px;
+}
+
+.tier-card h3 {
+    font-size: 20px;
+    margin-bottom: 15px;
+    color: #2c3e50;
+}
+
+.tier-card .price {
+    font-size: 36px;
+    font-weight: bold;
+    color: #3498db;
+    margin-bottom: 20px;
+}
+
+.tier-card .price span {
+    font-size: 16px;
+    color: #7f8c8d;
+}
+
+.tier-card ul {
+    list-style: none;
+    margin-bottom: 25px;
+    text-align: left;
+}
+
+.tier-card ul li {
+    padding: 8px 0;
+    border-bottom: 1px solid #eee;
+    color: #555;
+}
+
+.tier-card ul li:last-child {
+    border-bottom: none;
+}
+
+.tier-button {
+    width: 100%;
+    padding: 12px;
+    background-color: #3498db;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.tier-button:hover {
+    background-color: #2980b9;
+}
+
+.platforms-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+}
+
+.platform-item {
+    background: white;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.platform-item img {
+    margin-bottom: 15px;
+}
+
+.platform-item p {
+    font-size: 14px;
+    color: #7f8c8d;
+}
+
+.btn-sponsor {
+    background-color: #e67e22;
+    color: white;
+    padding: 8px 16px;
+    text-decoration: none;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 14px;
+    transition: background 0.3s;
+}
+
+.btn-sponsor:hover {
+    background-color: #d35400;
+}
+
 /* Table styles for Ops page */
 table {
     width: 100%;

--- a/app/funding.html
+++ b/app/funding.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sponsorship & Funding - IT Suite</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="sidebar">
+        <div class="logo">IT Suite</div>
+        <nav>
+            <ul>
+                <li><a href="index.html">Dashboard</a></li>
+                <li><a href="ops.html">IT Operations</a></li>
+                <li><a href="projects.html">Project Management</a></li>
+                <li><a href="security.html">Cybersecurity</a></li>
+                <li><a href="ai-assistant.html">AI Assistant</a></li>
+                <li class="active"><a href="funding.html">Sponsorship & Funding</a></li>
+            </ul>
+        </nav>
+    </div>
+    <main>
+        <header>
+            <h1>Support Our Mission</h1>
+            <div class="user-profile">Admin User</div>
+        </header>
+
+        <section class="funding-overview">
+            <div class="stat-card full-width">
+                <h3>Fundraising Progress</h3>
+                <div class="progress-container">
+                    <div class="progress-bar" style="width: 65%;">65%</div>
+                </div>
+                <p style="margin-top: 10px;">$6,500 raised of $10,000 monthly goal</p>
+            </div>
+        </section>
+
+        <section class="funding-tiers">
+            <div class="tier-card">
+                <h3>Community</h3>
+                <div class="price">$5<span>/mo</span></div>
+                <ul>
+                    <li>Recognition on GitHub</li>
+                    <li>Community Discord access</li>
+                    <li>Monthly newsletter</li>
+                </ul>
+                <button class="tier-button">Back on Patreon</button>
+            </div>
+            <div class="tier-card featured">
+                <h3>Professional</h3>
+                <div class="price">$25<span>/mo</span></div>
+                <ul>
+                    <li>All Community perks</li>
+                    <li>Early access to features</li>
+                    <li>Priority bug reports</li>
+                    <li>Exclusive webinars</li>
+                </ul>
+                <button class="tier-button">Sponsor on GitHub</button>
+            </div>
+            <div class="tier-card">
+                <h3>Enterprise</h3>
+                <div class="price">$100<span>/mo</span></div>
+                <ul>
+                    <li>All Pro perks</li>
+                    <li>Custom feature requests</li>
+                    <li>1-on-1 support calls</li>
+                    <li>Logo on our website</li>
+                </ul>
+                <button class="tier-button">Join Open Collective</button>
+            </div>
+        </section>
+
+        <section class="sponsorship-platforms" style="margin-top: 30px;">
+            <h2>Other Ways to Support</h2>
+            <div class="platforms-grid">
+                <div class="platform-item">
+                    <img src="https://img.shields.io/badge/Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white" alt="Patreon">
+                    <p>Support our continuous development on Patreon.</p>
+                </div>
+                <div class="platform-item">
+                    <img src="https://img.shields.io/badge/GitHub_Sponsors-EA4AAA?style=for-the-badge&logo=github-sponsors&logoColor=white" alt="GitHub Sponsors">
+                    <p>Sponsor the maintainers directly via GitHub.</p>
+                </div>
+                <div class="platform-item">
+                    <img src="https://img.shields.io/badge/Open_Collective-7B9EFE?style=for-the-badge&logo=open-collective&logoColor=white" alt="Open Collective">
+                    <p>Transparent funding for our open source project.</p>
+                </div>
+            </div>
+        </section>
+    </main>
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/app/index.html
+++ b/app/index.html
@@ -17,13 +17,17 @@
                 <li><a href="projects.html">Project Management</a></li>
                 <li><a href="security.html">Cybersecurity</a></li>
                 <li><a href="ai-assistant.html">AI Assistant</a></li>
+                <li><a href="funding.html">Sponsorship & Funding</a></li>
             </ul>
         </nav>
     </div>
     <main>
         <header>
             <h1>Dashboard Overview</h1>
-            <div class="user-profile">Admin User</div>
+            <div style="display: flex; align-items: center; gap: 20px;">
+                <a href="funding.html" class="btn-sponsor">Sponsor Project</a>
+                <div class="user-profile">Admin User</div>
+            </div>
         </header>
         <section class="stats-grid">
             <div class="stat-card">

--- a/app/ops.html
+++ b/app/ops.html
@@ -16,6 +16,7 @@
                 <li><a href="projects.html">Project Management</a></li>
                 <li><a href="security.html">Cybersecurity</a></li>
                 <li><a href="ai-assistant.html">AI Assistant</a></li>
+                <li><a href="funding.html">Sponsorship & Funding</a></li>
             </ul>
         </nav>
     </div>

--- a/app/projects.html
+++ b/app/projects.html
@@ -16,6 +16,7 @@
                 <li class="active"><a href="projects.html">Project Management</a></li>
                 <li><a href="security.html">Cybersecurity</a></li>
                 <li><a href="ai-assistant.html">AI Assistant</a></li>
+                <li><a href="funding.html">Sponsorship & Funding</a></li>
             </ul>
         </nav>
     </div>

--- a/app/security.html
+++ b/app/security.html
@@ -17,6 +17,7 @@
                 <li><a href="projects.html">Project Management</a></li>
                 <li class="active"><a href="security.html">Cybersecurity</a></li>
                 <li><a href="ai-assistant.html">AI Assistant</a></li>
+                <li><a href="funding.html">Sponsorship & Funding</a></li>
             </ul>
         </nav>
     </div>


### PR DESCRIPTION
Added a comprehensive "Sponsorship & Funding" module to the IT Suite prototype. This includes a new dedicated page (`app/funding.html`) showcasing fundraising progress, tiered sponsorship options (Community, Professional, Enterprise), and integrations with platforms like Patreon, GitHub Sponsors, and Open Collective. The module is fully integrated into the existing navigation and includes a prominent call-to-action on the dashboard.

---
*PR created automatically by Jules for task [10246000850493506728](https://jules.google.com/task/10246000850493506728) started by @GYFX35*

## Summary by Sourcery

Introduce a dedicated Sponsorship & Funding section to showcase fundraising progress and monetization options across the IT Suite prototype.

New Features:
- Add a Sponsorship & Funding page with fundraising progress, tiered plans, and external platform options for supporting the project.
- Integrate sponsorship navigation entry into all main app pages and add a sponsor call-to-action button on the dashboard header.

Enhancements:
- Extend global styling to support funding-specific components such as progress bars, tier cards, sponsorship platform tiles, and sponsor buttons.